### PR TITLE
Fix bug in parameter logic and introduce a "namespace"

### DIFF
--- a/DotNetVersionLister.psd1
+++ b/DotNetVersionLister.psd1
@@ -21,6 +21,14 @@
 #        the switch to true (_that_ is not best practices..). The rest of the logic
 #        should make this work seamlessly. Altered a comment/error message to reflect
 #        the change.
+# v2.2.7: Make sure you can pass -PSRemoting and -ComputerName without having to work
+#         around my idiocy and lack of testing by passing -Localhost:$False - like I found
+#         myself doing when actually testing the module against remote targets (that is not
+#         so conveniently done the way I currently work... sigh, sorry).
+# v3.0: 2.2.7 is skipped and I'm adding a new function name that's Get-STDotNetVersion, but
+#       to keep it backwards compatible, I will add some quite offensive logic to alias this to
+#       "Get-DotNetVersion", but only if the command does not already exist in the session.
+#       Fingers crossed I get the logic right, I promise to test. :)
 
 @{
 
@@ -28,7 +36,7 @@
 RootModule = 'DotNetVersionLister.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.6'
+ModuleVersion = '3.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -43,7 +51,7 @@ Author = 'Joakim Borger Svendsen'
 CompanyName = 'Svendsen Tech'
 
 # Copyright statement for this module
-Copyright = '(C) 2011 Svendsen Tech. Joakim Borger Svendsen. All rights reserved.'
+Copyright = '(C) 2011-present Svendsen Tech. Joakim Borger Svendsen. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Use Svendsen Tech''s Get-DotNetVersion function to list installed .NET versions up to the last hard-coded, known "Release" registry key value. GitHub here: https://github.com/EliteLoser/DotNetVersionLister/ - Online blog documentation here: https://www.powershelladmin.com/wiki/List_installed_.NET_versions_on_remote_computers'
@@ -85,7 +93,7 @@ PowerShellVersion = '2.0'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Get-DotNetVersion'
+FunctionsToExport = 'Get-STDotNetVersion'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()
@@ -103,7 +111,7 @@ AliasesToExport = @()
 # ModuleList = @()
 
 # List of all files packaged with this module
-# FileList = @()
+FileList = @("Get-DotNetVersion.psm1", "Get-DotNetVersion.psd1")
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
@@ -114,16 +122,17 @@ PrivateData = @{
         Tags = '.NET', 'Version', 'DotNet'
 
         # A URL to the license for this module.
-        # LicenseUri = ''
+        LicenseUri = 'https://github.com/EliteLoser/DotNetVersionLister/blob/master/LICENSE'
 
         # A URL to the main website for this project.
-        # ProjectUri = ''
+        ProjectUri = 'https://github.com/EliteLoser/DotNetVersionLister'
 
         # A URL to an icon representing this module.
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '* Make the -LocalHost parameter optional and the default behaviour to conform more to best practices (on the surface).'
+        ReleaseNotes = '* Fix critical bug in parameter logic. With version 2.2.6 you need to specify -Localhost:$False' + `
+            ' if passing the parameter -PSRemoting and targeting remote computers. This is no longer a problem.'
 
         # External dependent modules of this module
         # ExternalModuleDependencies = ''
@@ -133,7 +142,7 @@ PrivateData = @{
  } # End of PrivateData hashtable
 
 # HelpInfo URI of this module
-# HelpInfoURI = ''
+HelpInfoURI = 'https://github.com/EliteLoser/DotNetVersionLister'
 
 # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
 # DefaultCommandPrefix = ''

--- a/DotNetVersionLister.psd1
+++ b/DotNetVersionLister.psd1
@@ -111,7 +111,7 @@ AliasesToExport = @()
 # ModuleList = @()
 
 # List of all files packaged with this module
-FileList = @("Get-DotNetVersion.psm1", "Get-DotNetVersion.psd1")
+FileList = @("DotNetVersionLister.psm1", "DotNetVersionLister.psd1")
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{

--- a/DotNetVersionLister.psm1
+++ b/DotNetVersionLister.psm1
@@ -1,4 +1,4 @@
-function Get-DotNetVersion {
+function Get-STDotNetVersion {
     <#
     .SYNOPSIS
         Get installed .NET versions from the local host or remote computers. Hardcoded .NET versions,
@@ -98,7 +98,15 @@ function Get-DotNetVersion {
     # ----- forgot to comment ---
     # 2018-12-26: v2.2.6 - Up to .NET 4.7.2 is supported in this version. The change is making the -LocalHost
     #                      parameter optional.
-    
+    # 2019-01-30: v2.2.7 - Make sure you can pass -PSRemoting and -ComputerName without having to work
+    #                      around my idiocy and lack of testing by passing -Localhost:$False - like I found
+    #                      myself doing when actually testing the module against remote targets (that is not
+    #                      so conveniently done the way I currently work... sigh, sorry).
+    # v3.0 - The 2.2.7 version is skipped and I'm adding a new function name that's Get-STDotNetVersion, but
+    #       to keep it backwards compatible, I will add some quite offensive logic to alias this to
+    #       "Get-DotNetVersion", but only if the command does not already exist in the session.
+    #       Fingers crossed I get the logic right on the first try this time, I promise to test. :)
+
     Begin {
         
         #Set-StrictMode -Version Latest
@@ -109,13 +117,13 @@ function Get-DotNetVersion {
         
         $StartTime = Get-Date
         
-        if ($PSRemoting -and $LocalHost) {
-            Write-Error -Message "You can't use both the PSRemoting and LocalHost parameter at the same time." -ErrorAction Stop
-        }
-        
         if ($ComputerName.Count -gt 0 -and $LocalHost) {
             Write-Verbose -Message "Using specified computer names."
             $LocalHost = $False
+        }
+
+        if ($PSRemoting -and $LocalHost) {
+            Write-Error -Message "You can't use both the PSRemoting and LocalHost parameter at the same time." -ErrorAction Stop
         }
 
         if (-not $LocalHost -and $ComputerName.Count -eq 0) {
@@ -349,4 +357,15 @@ function Get-DotNetVersion {
 "@
         }
     }
+}
+
+if (-not (Get-Command -Name Get-DotNetVersion -ErrorAction SilentlyContinue)) {
+
+    Write-Verbose ("As of version 3.x (and higher) of the module, the function name is 'Get-STDotNetVersion' to " + `
+        "avoid function name collisions. However, this PowerShell session did not have a 'Get-DotNetVersion' command in use," + `
+        "so to preserve backwards-compatibility, the alias 'Get-DotNetVersion' now points to the function 'Get-STDotNetVersion'.")
+
+    New-Alias -Name Get-DotNetVersion -Value Get-STDotNetVersion `
+        -Description "Backwards compatibility alias for 'Get-STDotNetVersion'." -ErrorAction Continue
+
 }

--- a/DotNetVersionLister.psm1
+++ b/DotNetVersionLister.psm1
@@ -366,6 +366,7 @@ if (-not (Get-Command -Name Get-DotNetVersion -ErrorAction SilentlyContinue)) {
         "so to preserve backwards-compatibility, the alias 'Get-DotNetVersion' now points to the function 'Get-STDotNetVersion'.")
 
     New-Alias -Name Get-DotNetVersion -Value Get-STDotNetVersion `
-        -Description "Backwards compatibility alias for 'Get-STDotNetVersion'." -ErrorAction Continue
+        -Description "Backwards compatibility alias for 'Get-STDotNetVersion'." -ErrorAction Continue `
+        -Scope Global
 
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DotNetVersionLister
-Get a list of installed .NET versions on (remote) Windows computers
+Get a list of installed .NET versions on (remote) Windows computers.
 
-As of 2018-12-26 versions up to .NET 4.7.2 are supported/detected. It's based on the information in this article: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
+As of 2019-01-30 versions up to .NET 4.7.2 are supported/detected. It's based on the information in this article: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
 
 Blog documentation (I'm too lazy to duplicate here): https://www.powershelladmin.com/wiki/List_installed_.NET_versions_on_remote_computers 
 
@@ -15,16 +15,16 @@ Install-Module -Name DotNetVersionLister -Scope CurrentUser #-Force
 
 Example use:
 
-`Get-DotNetVersion`
+`Get-STDotNetVersion`
 
 and
 
-`Get-DotNetVersion -ComputerName server1, server2, server3`.
+`Get-STDotNetVersion -ComputerName server1, server2, server3`.
 
 Example output:
 
 ```
-Get-DotNetVersion -NoSummary
+Get-STDotNetVersion -NoSummary
 
 
 ComputerName : localhost
@@ -38,3 +38,7 @@ v1.1.4322    : Not installed (no key)
 Ping         : True
 Error        : 
 ```
+
+# Notes
+
+The command/function name used to be `Get-DotNetVersion` in versions before v3 of the module. This is aliased if the command does not currently exist in the PowerShell session, but you have to either run `Get-STDotNetVersion` first to load it, as auto-load for `Get-DotNetVersion` does not work - or you can simply `Import-Module -Name DotNetVersionLister` first, as we had to on PowerShell v2.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ and
 
 `Get-STDotNetVersion -ComputerName server1, server2, server3`.
 
+or
+
+`Get-STDotNetVersion -ComputerName server1, server2, server3 -PSRemoting`.
+
 Example output:
 
 ```

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Example use:
 
 and
 
-`Get-STDotNetVersion -ComputerName server1, server2, server3`.
+`Get-STDotNetVersion -ComputerName server1, server2, server3`
 
 or
 
-`Get-STDotNetVersion -ComputerName server1, server2, server3 -PSRemoting`.
+`Get-STDotNetVersion -ComputerName server1, server2, server3 -PSRemoting`
 
 Example output:
 


### PR DESCRIPTION
v3. Major version change because I'm changing the function name to `Get-STDotNetVersion`. An alias will be added for `Get-DotNetversion` ''if it does not already exist'' in the current PowerShell session. However, auto-load does not work for this command, so I'm major bumping the version number. Better now than later... Fixed a critical bug that made you have to pass -Localhost:$False when using -ComputerName and -PSRemoting together for it to work.