### PR TITLE
Updated module to support up to 4.8.1

### DIFF
--- a/DotNetVersionLister.psd1
+++ b/DotNetVersionLister.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DotNetVersionLister.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.0.1'
+ModuleVersion = '3.1.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Added a private function to simplify extraction of .Net 4.x display values. Added detection for frameworks up to 4.8.1 (build 533320). 
The display value will have an added "+" if it gets a build number not listed in the version hashtable (e.g. Get-DotNet4xVersion -BuildNumber 470000 yields ".NET Framework 4.7.2+" since 470000 is greater than 461808 (which is 4.7.2) and less than 528040 (which is 4.8). 